### PR TITLE
Better support for user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ from a remote peer is:
 
 ## TODO
 
-- Implement functions for [BIP 0014](https://en.bitcoin.it/wiki/BIP_0014)
 - Implement alert message decoding/encoding
 - Implement bloom filter messages (filterload, filteradd, filterclear,
   merkleblock) as defined in [BIP 0037](https://en.bitcoin.it/wiki/BIP_0037)

--- a/doc.go
+++ b/doc.go
@@ -150,6 +150,7 @@ Bitcoin Improvement Proposals
 
 This package includes spec changes outlined by the following BIPs:
 
+		BIP0014 (https://en.bitcoin.it/wiki/BIP_0014)
 		BIP0031 (https://en.bitcoin.it/wiki/BIP_0031)
 		BIP0035 (https://en.bitcoin.it/wiki/BIP_0035)
 

--- a/message_test.go
+++ b/message_test.go
@@ -51,7 +51,7 @@ func TestMessage(t *testing.T) {
 		t.Errorf("NewNetAddress: %v", err)
 	}
 	me.Timestamp = time.Time{} // Version message has zero value timestamp.
-	msgVersion := btcwire.NewMsgVersion(me, you, 123123, "/test:0.0.1/", 0)
+	msgVersion := btcwire.NewMsgVersion(me, you, 123123, 0)
 
 	msgVerack := btcwire.NewMsgVerAck()
 	msgGetAddr := btcwire.NewMsgGetAddr()
@@ -76,7 +76,7 @@ func TestMessage(t *testing.T) {
 		btcnet btcwire.BitcoinNet // Network to use for wire encoding
 		bytes  int                // Expected num bytes read/written
 	}{
-		{msgVersion, msgVersion, pver, btcwire.MainNet, 122},
+		{msgVersion, msgVersion, pver, btcwire.MainNet, 125},
 		{msgVerack, msgVerack, pver, btcwire.MainNet, 24},
 		{msgGetAddr, msgGetAddr, pver, btcwire.MainNet, 24},
 		{msgAddr, msgAddr, pver, btcwire.MainNet, 25},


### PR DESCRIPTION
Refs #10

We're defaulting the UA to `/btcwire:0.0.1/` (hardcoded right now as I'm not sure how to inspect the current version) and allowing customization using `AddUserAgent`. I've also moved the validation to a new function `validateUserAgent` for re-usability. Also, the validation can be extended to cover reserved symbols: `['/', ':', '(', ')']`.

Added tests with/without comments.
