### PR TITLE
Implement alert message serialize/deserialize

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -19,6 +19,14 @@ import (
 // the test package.
 const MaxMessagePayload uint32 = maxMessagePayload
 
+// MaxCountSetCancel makes the internal maxCountSetCancel constant available to
+// the test package.
+const MaxCountSetCancel uint32 = maxCountSetCancel
+
+// MaxCountSetSubVer makes the internal maxCountSetSubVer constant available to
+// the test package.
+const MaxCountSetSubVer uint32 = maxCountSetSubVer
+
 // CommandSize makes the internal commandSize constant available to the test
 // package.
 const CommandSize = commandSize
@@ -63,6 +71,18 @@ func TstReadVarString(r io.Reader, pver uint32) (string, error) {
 // test package.
 func TstWriteVarString(w io.Writer, pver uint32, str string) error {
 	return writeVarString(w, pver, str)
+}
+
+// TstReadVarBytes makes the internal readVarBytes function available to the
+// test package.
+func TstReadVarBytes(r io.Reader, pver uint32, maxAllowed uint32, fieldName string) ([]byte, error) {
+	return readVarBytes(r, pver, maxAllowed, fieldName)
+}
+
+// TstWriteVarBytes makes the internal writeVarBytes function available to the
+// test package.
+func TstWriteVarBytes(w io.Writer, pver uint32, bytes []byte) error {
+	return writeVarBytes(w, pver, bytes)
 }
 
 // TstReadNetAddress makes the internal readNetAddress function available to

--- a/message_test.go
+++ b/message_test.go
@@ -66,7 +66,7 @@ func TestMessage(t *testing.T) {
 	msgPong := btcwire.NewMsgPong(123123)
 	msgGetHeaders := btcwire.NewMsgGetHeaders()
 	msgHeaders := btcwire.NewMsgHeaders()
-	msgAlert := btcwire.NewMsgAlert("payload", "signature")
+	msgAlert := btcwire.NewMsgAlert([]byte("payload"), []byte("signature"))
 	msgMemPool := btcwire.NewMsgMemPool()
 
 	tests := []struct {

--- a/msgalert.go
+++ b/msgalert.go
@@ -5,8 +5,316 @@
 package btcwire
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 )
+
+// MsgAlert contains a payload and a signature:
+//
+//        ===============================================
+//        |   Field         |   Data Type   |   Size    |
+//        ===============================================
+//        |   payload       |   []uchar     |   ?       |
+//        -----------------------------------------------
+//        |   signature     |   []uchar     |   ?       |
+//        -----------------------------------------------
+//
+// Here payload is an Alert serialized into a byte array to ensure that
+// versions using incompatible alert formats can still relay
+// alerts among one another.
+//
+// An Alert is the payload deserialized as follows:
+//
+//        ===============================================
+//        |   Field         |   Data Type   |   Size    |
+//        ===============================================
+//        |   Version       |   int32       |   4       |
+//        -----------------------------------------------
+//        |   RelayUntil    |   int64       |   8       |
+//        -----------------------------------------------
+//        |   Expiration    |   int64       |   8       |
+//        -----------------------------------------------
+//        |   ID            |   int32       |   4       |
+//        -----------------------------------------------
+//        |   Cancel        |   int32       |   4       |
+//        -----------------------------------------------
+//        |   SetCancel     |   set<int32>  |   ?       |
+//        -----------------------------------------------
+//        |   MinVer        |   int32       |   4       |
+//        -----------------------------------------------
+//        |   MaxVer        |   int32       |   4       |
+//        -----------------------------------------------
+//        |   SetSubVer     |   set<string> |   ?       |
+//        -----------------------------------------------
+//        |   Priority      |   int32       |   4       |
+//        -----------------------------------------------
+//        |   Comment       |   string      |   ?       |
+//        -----------------------------------------------
+//        |   StatusBar     |   string      |   ?       |
+//        -----------------------------------------------
+//        |   Reserved      |   string      |   ?       |
+//        -----------------------------------------------
+//        |   Total  (Fixed)                |   45      |
+//        -----------------------------------------------
+//
+// note:
+//      * string is a VarString i.e VarInt length followed by the string itself
+//      * set<string> is a VarInt followed by as many number of strings
+//      * set<int32> is a VarInt followed by as many number of ints
+//      * fixedAlertSize = 40 + 5*min(VarInt)  = 40 + 5*1 = 45
+
+// Now we can define bounds on Alert size, SetCancel and SetSubVer
+
+// Fixed size of the alert payload
+const fixedAlertSize = 45
+
+// Max size of the ECDSA signature
+// note: since this size is fixed and < 255, size of VarInt
+// required = 1 (fits in uint8)
+const maxSignatureSize = 72
+
+// Maximum size of the alert
+// MessagePayload = VarInt(Alert) + Alert + VarInt(Signature) + Signature
+// maxMessagePayload = maxAlertSize + max(VarInt) + maxSignatureSize + 1
+const maxAlertSize = maxMessagePayload - maxSignatureSize - MaxVarIntPayload - 1
+
+// Maximum number of Cancel IDs from SetCancel to read
+// maxAlertSize = fixedAlertSize + max(SetCancel) + max(SetSubVer) + 3*(string)
+// for caculating maximum number of Cancel IDs, set all other variable sizes to 0
+// maxAlertSize = fixedAlertSize + (MaxVarIntPayload-1) + x*sizeOf(int32)
+// x = (maxAlertSize - fixedAlertSize - MaxVarIntPayload + 1) / 4
+const maxCountSetCancel = (maxAlertSize - fixedAlertSize - MaxVarIntPayload + 1) / 4
+
+// Maximum number of subversions from SetSubVer to read
+// maxAlertSize = fixedAlertSize + max(SetCancel) + max(SetSubVer) + 3*(string)
+// for caculating maximum number of subversions, set all other variable sizes to 0
+// maxAlertSize = fixedAlertSize + (MaxVarIntPayload-1) + x*sizeOf(string)
+// x = (maxAlertSize - fixedAlertSize - MaxVarIntPayload + 1) / sizeOf(string)
+// subversion would typically be something like "/Satoshi:0.7.2/" (15 bytes)
+// so assuming < 255 bytes, sizeOf(string) = sizeOf(uint8) + 255 = 256
+const maxCountSetSubVer = (maxAlertSize - fixedAlertSize - MaxVarIntPayload + 1) / 256
+
+// Alert contains the data deserialized from the MsgAlert payload
+type Alert struct {
+
+	// Alert format version
+	Version int32
+
+	// Timestamp beyond which nodes should stop relaying this alert
+	RelayUntil int64
+
+	// Timestamp beyond which this alert is no longer in effect and
+	// should be ignored
+	Expiration int64
+
+	// A unique ID number for this alert
+	ID int32
+
+	// All alerts with an ID less than or equal to this number should
+	// cancelled, deleted and not accepted in the future
+	Cancel int32
+
+	// All alert IDs contained in this set should be cancelled as above
+	SetCancel []int32
+
+	// This alert only applies to versions greater than or equal to this
+	// version. Other versions should still relay it.
+	MinVer int32
+
+	// This alert only applies to versions less than or equal to this version.
+	// Other versions should still relay it.
+	MaxVer int32
+
+	// If this set contains any elements, then only nodes that have their
+	// subVer contained in this set are affected by the alert. Other versions
+	// should still relay it.
+	SetSubVer []string
+
+	// Relative priority compared to other alerts
+	Priority int32
+
+	// A comment on the alert that is not displayed
+	Comment string
+
+	// The alert message that is displayed to the user
+	StatusBar string
+
+	// Reserved
+	Reserved string
+}
+
+// NewAlert returns an new Alert with values provided
+func NewAlert(version int32, relayuntil int64, expiration int64,
+	id int32, cancel int32, setcancel []int32, minver int32,
+	maxver int32, setsubver []string, priority int32, comment string,
+	statusbar string, reserved string) *Alert {
+	return &Alert{
+		Version:    version,
+		RelayUntil: relayuntil,
+		Expiration: expiration,
+		ID:         id,
+		Cancel:     cancel,
+		SetCancel:  setcancel,
+		MinVer:     minver,
+		MaxVer:     maxver,
+		SetSubVer:  setsubver,
+		Priority:   priority,
+		Comment:    comment,
+		StatusBar:  statusbar,
+		Reserved:   reserved,
+	}
+}
+
+// NewAlertFromPayload returns an Alert with values deserialized
+// from the serializedpayload
+func NewAlertFromPayload(serializedpayload []byte, pver uint32) (*Alert, error) {
+	var alert Alert
+	r := bytes.NewReader(serializedpayload)
+	err := alert.Deserialize(r, pver)
+	if err != nil {
+		return nil, err
+	}
+	return &alert, nil
+}
+
+// Serialize writes a serialized byte array of the Alert
+func (alert *Alert) Serialize(w io.Writer, pver uint32) error {
+	err := writeElements(w, &alert.Version,
+		&alert.RelayUntil, &alert.Expiration, &alert.ID, &alert.Cancel)
+	if err != nil {
+		return err
+	}
+
+	count := len(alert.SetCancel)
+	if count > maxCountSetCancel {
+		str := fmt.Sprintf("too many cancel alert IDs for alert "+
+			"[count %v, max %v]", count, maxCountSetCancel)
+		return messageError("Alert.Serialize", str)
+	}
+	err = writeVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		err = writeElement(w, &alert.SetCancel[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	err = writeElements(w, &alert.MinVer, &alert.MaxVer)
+	if err != nil {
+		return err
+	}
+
+	count = len(alert.SetSubVer)
+	if count > maxCountSetSubVer {
+		str := fmt.Sprintf("too many sub versions for alert "+
+			"[count %v, max %v]", count, maxCountSetSubVer)
+		return messageError("Alert.Serialize", str)
+	}
+	err = writeVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		err = writeVarString(w, pver, alert.SetSubVer[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	err = writeElement(w, &alert.Priority)
+	if err != nil {
+		return err
+	}
+	err = writeVarString(w, pver, alert.Comment)
+	if err != nil {
+		return err
+	}
+	err = writeVarString(w, pver, alert.StatusBar)
+	if err != nil {
+		return err
+	}
+	err = writeVarString(w, pver, alert.Reserved)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Deserialize reads a byte array, deserializes
+// it and updates the Alert
+func (alert *Alert) Deserialize(r io.Reader, pver uint32) error {
+	err := readElements(r, &alert.Version, &alert.RelayUntil,
+		&alert.Expiration, &alert.ID, &alert.Cancel)
+	if err != nil {
+		return err
+	}
+
+	// SetCancel: first read a VarInt that contains
+	// count - the number of Cancel IDs, then
+	// iterate count times and read them
+	count, err := readVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if count > maxCountSetCancel {
+		str := fmt.Sprintf("too many cancel alert IDs for alert "+
+			"[count %v, max %v]", count, maxCountSetCancel)
+		return messageError("Alert.Deserialize", str)
+	}
+	alert.SetCancel = make([]int32, count)
+	for i := 0; i < int(count); i++ {
+		err := readElement(r, &alert.SetCancel[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	err = readElements(r, &alert.MinVer, &alert.MaxVer)
+	if err != nil {
+		return err
+	}
+
+	// SetSubVer: similar to SetCancel
+	// but read count number of sub-version strings
+	count, err = readVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if count > maxCountSetSubVer {
+		str := fmt.Sprintf("too many sub versions for alert "+
+			"[count %v, max %v]", count, maxCountSetSubVer)
+		return messageError("Alert.Deserialize", str)
+	}
+	alert.SetSubVer = make([]string, count)
+	for i := 0; i < int(count); i++ {
+		alert.SetSubVer[i], err = readVarString(r, pver)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = readElement(r, &alert.Priority)
+	if err != nil {
+		return err
+	}
+	alert.Comment, err = readVarString(r, pver)
+	if err != nil {
+		return err
+	}
+	alert.StatusBar, err = readVarString(r, pver)
+	if err != nil {
+		return err
+	}
+	alert.Reserved, err = readVarString(r, pver)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 // MsgAlert  implements the Message interface and defines a bitcoin alert
 // message.
@@ -15,24 +323,36 @@ import (
 // display if the signature matches the key.  bitcoind/bitcoin-qt only checks
 // against a signature from the core developers.
 type MsgAlert struct {
-	// PayloadBlob is the alert payload serialized as a string so that the
+	// SerializedPayload is the alert payload serialized as a string so that the
 	// version can change but the Alert can still be passed on by older
 	// clients.
-	PayloadBlob string
+	SerializedPayload []byte
 
 	// Signature is the ECDSA signature of the message.
-	Signature string
+	Signature []byte
+
+	// Deserialized Payload
+	Payload *Alert
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgAlert) BtcDecode(r io.Reader, pver uint32) error {
 	var err error
-	msg.PayloadBlob, err = readVarString(r, pver)
+
+	msg.SerializedPayload, err = readVarBytes(r, pver, maxMessagePayload,
+		"alert serialized payload")
 	if err != nil {
 		return err
 	}
-	msg.Signature, err = readVarString(r, pver)
+
+	msg.Payload, err = NewAlertFromPayload(msg.SerializedPayload, pver)
+	if err != nil {
+		msg.Payload = nil
+	}
+
+	msg.Signature, err = readVarBytes(r, pver, maxMessagePayload,
+		"alert signature")
 	if err != nil {
 		return err
 	}
@@ -44,15 +364,33 @@ func (msg *MsgAlert) BtcDecode(r io.Reader, pver uint32) error {
 // This is part of the Message interface implementation.
 func (msg *MsgAlert) BtcEncode(w io.Writer, pver uint32) error {
 	var err error
-	err = writeVarString(w, pver, msg.PayloadBlob)
+	var serializedpayload []byte
+	if msg.Payload != nil {
+		// try to Serialize Payload if possible
+		r := new(bytes.Buffer)
+		err = msg.Payload.Serialize(r, pver)
+		if err != nil {
+			// Serialize failed - ignore & fallback
+			// to SerializedPayload
+			serializedpayload = msg.SerializedPayload
+		} else {
+			serializedpayload = r.Bytes()
+		}
+	} else {
+		serializedpayload = msg.SerializedPayload
+	}
+	slen := uint64(len(serializedpayload))
+	if slen == 0 {
+		return messageError("MsgAlert.BtcEncode", "empty serialized payload")
+	}
+	err = writeVarBytes(w, pver, serializedpayload)
 	if err != nil {
 		return err
 	}
-	err = writeVarString(w, pver, msg.Signature)
+	err = writeVarBytes(w, pver, msg.Signature)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -72,9 +410,10 @@ func (msg *MsgAlert) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgAlert returns a new bitcoin alert message that conforms to the Message
 // interface.  See MsgAlert for details.
-func NewMsgAlert(payloadblob string, signature string) *MsgAlert {
+func NewMsgAlert(serializedpayload []byte, signature []byte) *MsgAlert {
 	return &MsgAlert{
-		PayloadBlob: payloadblob,
-		Signature:   signature,
+		SerializedPayload: serializedpayload,
+		Signature:         signature,
+		Payload:           nil,
 	}
 }


### PR DESCRIPTION
Refs #11

I've implemented the new struct `Alert` and functions `NewAlert`, `NewAlertFromPayload`, `Serialize`, `Deserialize`.

I was able to verify that deserialization works for the example given at:

https://en.bitcoin.it/wiki/Protocol_specification#alert

Not sure if we should have this example hardcoded in the tests.

~~Still working on a few things like updating `NewMsgAlert`, `BtcDecode` to load the `Alert` and fixing the coverage.~~

Just need to fix coverage.

I had to add a few functions like `readIntSet`, `readStringSet`, `writeIntSet`, `writeStringSet` but not sure if this is the best way. Is this where `reflect` comes into the picture?
